### PR TITLE
Error with the variable types in the `drawLine` parser function

### DIFF
--- a/lib/dec.05.js
+++ b/lib/dec.05.js
@@ -7,7 +7,7 @@ export class VentMap {
 
   drawLine(line) {
     let [ , ...[ x1, y1, x2, y2 ] ] = line.match(/^(\d+),(\d+) \-> (\d+),(\d+)$/)
-    this.drawLineFromPoints( { x: x1, y: y1 }, { x: x2, y: y2 })
+    this.drawLineFromPoints( { x: Number(x1), y: Number(y1) }, { x: Number(x2), y: Number(y2) })
   }
 
   drawLineFromPoints(start, end) {


### PR DESCRIPTION
The points generated in `drawLine` are strings and they need to be transformed into numbers before going into the `drawLineFromPoints` function, otherwise they end up messing up all the indexes of the data array.

You also have to be careful with the value of `lineCount` function in the tests. it is OK to check that value it in the tests, but the problem never asks about that number. The correct solution is the result of the `intersectionCount` function (btw both values need to be updated in the `compute response`function on the test suit with the new values after the fix).